### PR TITLE
remove operations clearing on saving

### DIFF
--- a/class-wp-image-editor-aws-lambda.php
+++ b/class-wp-image-editor-aws-lambda.php
@@ -141,8 +141,6 @@ class WP_Image_Editor_AWS_Lambda extends WP_Image_Editor {
 
         $promise = $this->_run_lambda_async( $new_key );
 
-        $this->_operations = [];
-
         return [
             'promise' => $promise,
             'meta' => [
@@ -177,8 +175,6 @@ class WP_Image_Editor_AWS_Lambda extends WP_Image_Editor {
         if( $result['StatusCode'] < 200 && $result['StatusCode'] >= 300 ) {
             return new WP_Error( 'image_save_error', $result['FunctionError'] );
         }
-
-        $this->_operations = [];
 
         // Set correct file permissions
         //$stat = stat( dirname( $filename ) );


### PR DESCRIPTION
There are no need to clear operations list in **save** method because we need to use this list in e.g. **multi_resize** method which is calling to generate new thumbnails after rotating, flipping etc. and in case when operations list is empty, previous image is used and it's wrong.